### PR TITLE
(Closes #1) updates for fc40 - README and xios patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ spack install aocc
 spack install llvm +cuda +flang +libomptarget +libomptarget_debug +mlir
 ```
 
-Set up the Spack compilers configuration:
+Set up the Spack compilers configuration (N.B. you may need to e.g. `spack load nvhpc`
+before spack will find the new packages):
 ```bash
 spack compiler find
 spack compilers

--- a/psyclone_additional_packages/packages/xios/package.py
+++ b/psyclone_additional_packages/packages/xios/package.py
@@ -43,10 +43,6 @@ class Xios(BaseXios):
                         "extern/remap/src/elt.hpp",
                         backup=True)
             
-            filter_file(r"//#include <cstdint>",
-                        "#include <cstdint>",
-                        "extern/remap/src/earcut.hpp",
-                        backup=True)
         elif self.spec.satisfies("%nvhpc"):
             # Nvidia have identified two problems with XIOS during
             # compiler testing on an Azure linux system and have
@@ -66,6 +62,19 @@ class Xios(BaseXios):
                 "src/node/mesh.cpp",
                 backup=True,
             )
+            filter_file(r"^(#include\s*<memory>\s*)$",
+                        "#include <array>\n\\1",
+                        "extern/remap/src/earcut.hpp",
+                        backup=True)
+
+        filter_file(r"//#include <cstdint>",
+                    "#include <cstdint>",
+                    "extern/remap/src/earcut.hpp",
+                    backup=True)
+        filter_file(r"//#include <tuple>",
+                    "#include <tuple>",
+                    "extern/remap/src/earcut.hpp",
+                    backup=True)
 
         return
 


### PR DESCRIPTION
It could be that we need to make the xios patches more specific to a glibc or gcc version. These work on my system but I've not tried elsewhere.